### PR TITLE
Add a Bun-native binary server path

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,5 +4,6 @@
 node_modules
 dist
 dist-server
+dist-bin
 .env.local
 tmux_toggle_issue.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
 dist/
 dist-server/
+dist-bin/
 .env.local

--- a/.vela.yml
+++ b/.vela.yml
@@ -9,6 +9,10 @@ secrets:
     key: zapplebee/docker_password
     engine: native
     type: org
+  - name: github_token
+    key: zapplebee/github_token
+    engine: native
+    type: org
 
 services:
   - name: ssh-fixture
@@ -66,3 +70,24 @@ steps:
       repo: harbor.prettybird.zapplebee.online/library/dynamic-lcars
       tags:
         - harbor.prettybird.zapplebee.online/library/dynamic-lcars:${VELA_BUILD_TAG##v}
+
+  - name: build-binary-tag
+    ruleset:
+      event: tag
+    image: oven/bun:1
+    pull: always
+    commands:
+      - cd ${VELA_WORKSPACE} && bun install --frozen-lockfile
+      - cd ${VELA_WORKSPACE} && bun run build:binary
+      - cd ${VELA_WORKSPACE} && cp dist-bin/dynamic-lcars dist-bin/dynamic-lcars-linux-x64
+
+  - name: upload-binary-tag
+    ruleset:
+      event: tag
+    image: ghcr.io/cli/cli:latest
+    pull: always
+    secrets:
+      - source: github_token
+        target: GH_TOKEN
+    commands:
+      - cd ${VELA_WORKSPACE} && gh release upload "${VELA_BUILD_TAG}" dist-bin/dynamic-lcars-linux-x64 --clobber --repo "${VELA_REPO_FULL_NAME}"

--- a/.vela.yml
+++ b/.vela.yml
@@ -84,10 +84,11 @@ steps:
   - name: upload-binary-tag
     ruleset:
       event: tag
-    image: ghcr.io/cli/cli:latest
+    image: target/vela-github-release:v0.5.0
     pull: always
-    secrets:
-      - source: github_token
-        target: GH_TOKEN
-    commands:
-      - cd ${VELA_WORKSPACE} && gh release upload "${VELA_BUILD_TAG}" dist-bin/dynamic-lcars-linux-x64 --clobber --repo "${VELA_REPO_FULL_NAME}"
+    secrets: [github_token]
+    parameters:
+      action: upload
+      files: [ dist-bin/dynamic-lcars-linux-x64 ]
+      tag: ${VELA_BUILD_TAG}
+      clobber: true

--- a/.vela.yml
+++ b/.vela.yml
@@ -32,11 +32,28 @@ services:
       - "until [ -f ${VELA_WORKSPACE}/tests/ci/start-app.sh ]; do sleep 1; done && /bin/sh ${VELA_WORKSPACE}/tests/ci/start-app.sh"
 
 steps:
+  - name: docker-build-smoke
+    image: target/vela-docker:latest
+    pull: always
+    secrets: [docker_username, docker_password]
+    parameters:
+      dry_run: true
+      registry: harbor.prettybird.zapplebee.online
+      repo: harbor.prettybird.zapplebee.online/library/dynamic-lcars
+      tags:
+        - harbor.prettybird.zapplebee.online/library/dynamic-lcars:ci-smoke
+
   - name: wait-for-services
     image: alpine:latest
     pull: always
     commands:
       - /bin/sh ${VELA_WORKSPACE}/tests/ci/wait-for-services.sh
+
+  - name: binary-runtime-smoke
+    image: node:24-bookworm
+    pull: always
+    commands:
+      - /bin/sh ${VELA_WORKSPACE}/tests/ci/smoke-binary.sh
 
   - name: cypress
     image: cypress/included:latest

--- a/.vela.yml
+++ b/.vela.yml
@@ -84,11 +84,14 @@ steps:
   - name: upload-binary-tag
     ruleset:
       event: tag
-    image: target/vela-github-release:v0.5.0
+    image: target/vela-github-release:latest
     pull: always
-    secrets: [github_token]
+    secrets:
+      - source: github_token
+        target: PARAMETER_TOKEN
     parameters:
       action: upload
+      hostname: github.com
       files: [ dist-bin/dynamic-lcars-linux-x64 ]
       tag: ${VELA_BUILD_TAG}
       clobber: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN bun install --frozen-lockfile --production
 FROM node:24-bookworm-slim AS runtime
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends openssh-client \
+  && apt-get install -y --no-install-recommends openssh-client util-linux \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The rest of this README is aimed at developers and coding agents working on the 
 The server expects these environment variables at runtime:
 
 - `LCARS_SSH_HOST`
+- `LCARS_SSH_PORT` (optional, defaults to `22`)
 - `LCARS_SSH_USER`
 - `LCARS_SSH_KEY_PATH`
 - `LCARS_SSH_KNOWN_HOSTS_PATH`
@@ -74,6 +75,7 @@ Run the backend server in a second terminal:
 
 ```bash
 export LCARS_SSH_HOST=example-host
+export LCARS_SSH_PORT=22
 export LCARS_SSH_USER=zac
 export LCARS_SSH_KEY_PATH=/absolute/path/to/id_ed25519
 export LCARS_SSH_KNOWN_HOSTS_PATH=/absolute/path/to/known_hosts
@@ -109,6 +111,7 @@ Run it directly:
 
 ```bash
 LCARS_SSH_HOST=example-host \
+LCARS_SSH_PORT=22 \
 LCARS_SSH_USER=zac \
 LCARS_SSH_KEY_PATH=/absolute/path/to/id_ed25519 \
 LCARS_SSH_KNOWN_HOSTS_PATH=/absolute/path/to/known_hosts \

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ LCARS_SSH_KNOWN_HOSTS_PATH=/absolute/path/to/known_hosts \
 ```
 
 The compiled server still expects the built frontend assets in `dist/` next to the binary.
+It also expects the host to provide `ssh` and `script` from `util-linux` so it can allocate interactive shell sessions without Docker.
 
 ## Docker image
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,30 @@ This produces:
 - frontend assets in `dist/`
 - bundled Node server in `dist-server/`
 
+## Bun Binary
+
+There is now an experimental Bun-native server path for shipping the app without Docker.
+
+Build the binary:
+
+```bash
+bun run build:binary
+```
+
+This produces `dist-bin/dynamic-lcars`.
+
+Run it directly:
+
+```bash
+LCARS_SSH_HOST=example-host \
+LCARS_SSH_USER=zac \
+LCARS_SSH_KEY_PATH=/absolute/path/to/id_ed25519 \
+LCARS_SSH_KNOWN_HOSTS_PATH=/absolute/path/to/known_hosts \
+./dist-bin/dynamic-lcars
+```
+
+The compiled server still expects the built frontend assets in `dist/` next to the binary.
+
 ## Docker image
 
 Build the image locally:

--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,6 @@
         "@hono/node-ws": "^1.3.0",
         "@xterm/addon-fit": "^0.11.0",
         "hono": "^4.12.8",
-        "node-pty": "^1.1.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "ws": "^8.19.0",
@@ -278,10 +277,6 @@
     "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": "bin/nanoid.cjs" }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
-
-    "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
-
-    "node-pty": ["node-pty@1.1.0", "", { "dependencies": { "node-addon-api": "^7.1.0" } }, "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg=="],
 
     "node-releases": ["node-releases@2.0.36", "", {}, "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA=="],
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -16,6 +16,7 @@ The app exposes one web interface on port `1701` and connects to the remote mach
 ```bash
 docker run --rm -p 1701:1701 \
   -e LCARS_SSH_HOST=example-host \
+  -e LCARS_SSH_PORT=22 \
   -e LCARS_SSH_USER=zac \
   -e LCARS_SSH_KEY_PATH=/run/secrets/id_ed25519 \
   -e LCARS_SSH_KNOWN_HOSTS_PATH=/run/secrets/known_hosts \
@@ -37,6 +38,7 @@ services:
       - "1701:1701"
     environment:
       LCARS_SSH_HOST: example-host
+      LCARS_SSH_PORT: 22
       LCARS_SSH_USER: zac
       LCARS_SSH_KEY_PATH: /run/secrets/id_ed25519
       LCARS_SSH_KNOWN_HOSTS_PATH: /run/secrets/known_hosts
@@ -49,6 +51,7 @@ services:
 ## Runtime environment
 
 - `LCARS_SSH_HOST` - required SSH hostname or address
+- `LCARS_SSH_PORT` - optional SSH port, defaults to `22`
 - `LCARS_SSH_USER` - required SSH username
 - `LCARS_SSH_KEY_PATH` - required in-container private key path
 - `LCARS_SSH_KNOWN_HOSTS_PATH` - required in-container `known_hosts` path

--- a/package.json
+++ b/package.json
@@ -5,9 +5,11 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "dev:server": "tsx watch server/index.ts",
+    "dev:server": "bun --watch server/index.ts",
     "build": "vite build && tsup server/index.ts --format esm --platform node --target node24 --out-dir dist-server --clean",
+    "build:binary": "vite build && bun build --compile server/index.ts --outfile dist-bin/dynamic-lcars",
     "preview": "vite preview",
+    "start:bun": "bun server/index.ts",
     "start": "NODE_ENV=production node dist-server/index.js",
     "test:e2e": "npx cypress run --browser chrome"
   },
@@ -16,7 +18,6 @@
     "@hono/node-ws": "^1.3.0",
     "@xterm/addon-fit": "^0.11.0",
     "hono": "^4.12.8",
-    "node-pty": "^1.1.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "ws": "^8.19.0",

--- a/server/config.ts
+++ b/server/config.ts
@@ -32,6 +32,7 @@ function readNumberEnv(name: string, fallback: number) {
 export type RuntimeConfig = {
   httpPort: number;
   sshHost: string;
+  sshPort: number;
   sshUser: string;
   sshKeyPath: string;
   sshKnownHostsPath: string;
@@ -42,6 +43,7 @@ export function loadConfig(): RuntimeConfig {
   return {
     httpPort: readNumberEnv("LCARS_HTTP_PORT", DEFAULT_HTTP_PORT),
     sshHost: readRequiredEnv("LCARS_SSH_HOST"),
+    sshPort: readNumberEnv("LCARS_SSH_PORT", 22),
     sshUser: readRequiredEnv("LCARS_SSH_USER"),
     sshKeyPath: readRequiredEnv("LCARS_SSH_KEY_PATH"),
     sshKnownHostsPath: readRequiredEnv("LCARS_SSH_KNOWN_HOSTS_PATH"),

--- a/server/ssh.ts
+++ b/server/ssh.ts
@@ -1,5 +1,9 @@
 import type { RuntimeConfig } from "./config";
 
+function shellQuote(value: string) {
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
 export function buildSshArgs(config: RuntimeConfig, remoteCommand?: string) {
   const args = [
     "-i",
@@ -18,4 +22,8 @@ export function buildSshArgs(config: RuntimeConfig, remoteCommand?: string) {
   }
 
   return args;
+}
+
+export function buildSshCommand(config: RuntimeConfig, remoteCommand?: string) {
+  return ["ssh", ...buildSshArgs(config, remoteCommand)].map(shellQuote).join(" ");
 }

--- a/server/ssh.ts
+++ b/server/ssh.ts
@@ -8,6 +8,8 @@ export function buildSshArgs(config: RuntimeConfig, remoteCommand?: string) {
   const args = [
     "-i",
     config.sshKeyPath,
+    "-p",
+    String(config.sshPort),
     "-o",
     "IdentitiesOnly=yes",
     "-o",

--- a/server/terminalSessionManager.ts
+++ b/server/terminalSessionManager.ts
@@ -1,8 +1,8 @@
 import crypto from "node:crypto";
 import process from "node:process";
-import pty, { type IPty } from "node-pty";
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import type { RuntimeConfig } from "./config";
-import { buildSshArgs } from "./ssh";
+import { buildSshCommand } from "./ssh";
 
 const MAX_BUFFER_LENGTH = 64_000;
 
@@ -20,7 +20,7 @@ export type ShellSummary = {
 type ManagedShellConnection = {
   shellId: string;
   label: string;
-  ptyProcess: IPty | null;
+  process: ChildProcessWithoutNullStreams | null;
   socket: TerminalSocket | null;
   buffer: string;
   lastSeenAt: number;
@@ -90,7 +90,7 @@ export class TerminalSessionManager {
     const connection: ManagedShellConnection = {
       shellId,
       label,
-      ptyProcess: null,
+      process: null,
       socket: null,
       buffer: "",
       lastSeenAt: Date.now(),
@@ -163,7 +163,7 @@ export class TerminalSessionManager {
     const session = this.sessions.get(sessionId);
     const connection = session?.connections.get(shellId);
 
-    connection?.ptyProcess?.write(data);
+    connection?.process?.stdin.write(data);
 
     if (session && connection) {
       session.lastSeenAt = Date.now();
@@ -175,7 +175,7 @@ export class TerminalSessionManager {
     const session = this.ensureSession(sessionId);
     const connection = this.ensureConnection(session, shellId);
 
-    if (!connection?.ptyProcess) {
+    if (!connection?.process) {
       throw new Error("Shell is unavailable.");
     }
 
@@ -193,7 +193,7 @@ export class TerminalSessionManager {
       }, 15000);
 
       connection.execRequests.push({ startMarker, endMarker, resolve, reject, timeoutId });
-      connection.ptyProcess?.write(`${disableEcho}printf '${startMarker}\n'; ${command}; printf '${endMarker}:%s\n' "$?"\n`);
+      connection.process?.stdin.write(`${disableEcho}printf '${startMarker}\n'; ${command}; printf '${endMarker}:%s\n' "$?"\n`);
     });
   }
 
@@ -201,11 +201,11 @@ export class TerminalSessionManager {
     const session = this.sessions.get(sessionId);
     const connection = session?.connections.get(shellId);
 
-    if (!session || !connection?.ptyProcess) {
+    if (!session || !connection?.process) {
       return;
     }
 
-    connection.ptyProcess.resize(cols, rows);
+    connection.process.stdin.write(`stty cols ${cols} rows ${rows}\n`);
     connection.lastSeenAt = Date.now();
     session.lastSeenAt = Date.now();
   }
@@ -228,7 +228,7 @@ export class TerminalSessionManager {
 
       for (const connection of session.connections.values()) {
         connection.socket?.close(1001, "idle timeout");
-        connection.ptyProcess?.kill();
+        connection.process?.kill();
       }
 
       this.sessions.delete(sessionId);
@@ -262,21 +262,20 @@ export class TerminalSessionManager {
       return null;
     }
 
-    if (connection.ptyProcess) {
+    if (connection.process) {
       return connection;
     }
 
-    const ptyProcess = pty.spawn("ssh", ["-tt", ...buildSshArgs(this.config, buildRemoteCommand())], {
-      name: "xterm-256color",
-      cols: 120,
-      rows: 40,
+    const child = spawn("script", ["-qfc", buildSshCommand(this.config, buildRemoteCommand()), "/dev/null"], {
       cwd: process.cwd(),
       env: process.env,
     });
 
-    connection.ptyProcess = ptyProcess;
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    connection.process = child;
 
-    ptyProcess.onData((chunk) => {
+    const handleChunk = (chunk: string) => {
       connection.lastSeenAt = Date.now();
       session.lastSeenAt = Date.now();
       connection.buffer = `${connection.buffer}${chunk}`.slice(-MAX_BUFFER_LENGTH);
@@ -285,16 +284,20 @@ export class TerminalSessionManager {
       if (connection.socket && connection.socket.readyState === 1) {
         connection.socket.send(JSON.stringify({ type: "output", data: chunk }));
       }
-    });
+    };
 
-    ptyProcess.onExit(() => {
+    child.stdout.on("data", handleChunk);
+    child.stderr.on("data", handleChunk);
+    child.stdin.write("stty cols 120 rows 40\n");
+
+    child.on("exit", () => {
       for (const request of connection.execRequests) {
         clearTimeout(request.timeoutId);
         request.reject(new Error("Shell exited before command completed."));
       }
 
       connection.execRequests = [];
-      connection.ptyProcess = null;
+      connection.process = null;
       connection.socket = null;
     });
 

--- a/server/terminalSessionManager.ts
+++ b/server/terminalSessionManager.ts
@@ -266,7 +266,7 @@ export class TerminalSessionManager {
       return connection;
     }
 
-    const child = spawn("script", ["-qfc", buildSshCommand(this.config, buildRemoteCommand()), "/dev/null"], {
+    const child = spawn("script", ["-E", "never", "-qefc", buildSshCommand(this.config, buildRemoteCommand()), "/dev/null"], {
       cwd: process.cwd(),
       env: process.env,
     });

--- a/tests/ci/smoke-binary.sh
+++ b/tests/ci/smoke-binary.sh
@@ -1,0 +1,98 @@
+#!/bin/sh
+
+set -eu
+
+export DEBIAN_FRONTEND=noninteractive
+
+if ! command -v ssh >/dev/null 2>&1 || ! command -v script >/dev/null 2>&1 || ! command -v python3 >/dev/null 2>&1; then
+  if [ "$(id -u)" -ne 0 ]; then
+    echo "ssh, script, and python3 must already be installed when not running as root"
+    exit 1
+  fi
+
+  apt-get update >/dev/null
+  apt-get install -y --no-install-recommends ca-certificates curl unzip python3 make g++ openssh-client util-linux >/dev/null
+fi
+
+export BUN_INSTALL=/root/.bun
+export PATH="$BUN_INSTALL/bin:$PATH"
+
+if ! command -v bun >/dev/null 2>&1; then
+  if [ "$(id -u)" -ne 0 ]; then
+    echo "bun must already be installed when not running as root"
+    exit 1
+  fi
+
+  curl -fsSL https://bun.sh/install | bash >/dev/null
+fi
+
+ssh_host=${LCARS_SSH_HOST:-ssh-fixture}
+ssh_port=${LCARS_SSH_PORT:-22}
+ssh_user=${LCARS_SSH_USER:-lcars}
+ssh_key_path=${LCARS_SSH_KEY_PATH:-$VELA_WORKSPACE/tests/fixtures/ssh/id_ed25519}
+ssh_known_hosts_path=${LCARS_SSH_KNOWN_HOSTS_PATH:-$VELA_WORKSPACE/tests/fixtures/ssh/known_hosts}
+
+cd "$VELA_WORKSPACE"
+chmod 600 "$ssh_key_path"
+chmod 644 "$ssh_known_hosts_path"
+
+bun install --frozen-lockfile >/dev/null
+bun run build:binary >/dev/null
+
+LCARS_SSH_HOST="$ssh_host" \
+LCARS_SSH_PORT="$ssh_port" \
+LCARS_SSH_USER="$ssh_user" \
+LCARS_SSH_KEY_PATH="$ssh_key_path" \
+LCARS_SSH_KNOWN_HOSTS_PATH="$ssh_known_hosts_path" \
+LCARS_HTTP_PORT=1702 \
+LCARS_DISABLE_TTY_ECHO=1 \
+LCARS_SESSION_IDLE_TTL_SECONDS=1800 \
+"$VELA_WORKSPACE/dist-bin/dynamic-lcars" > /tmp/dynamic-lcars-binary.log 2>&1 &
+
+binary_pid=$!
+
+cleanup() {
+  kill "$binary_pid" >/dev/null 2>&1 || true
+  wait "$binary_pid" >/dev/null 2>&1 || true
+}
+
+trap cleanup EXIT
+
+for i in $(seq 1 60); do
+  if curl -sf http://127.0.0.1:1702/api/health >/dev/null; then
+    break
+  fi
+
+  if [ "$i" -eq 60 ]; then
+    cat /tmp/dynamic-lcars-binary.log
+    echo "binary health endpoint never became ready"
+    exit 1
+  fi
+
+  sleep 1
+done
+
+python3 - <<'PY'
+import json, os, urllib.request
+
+base = 'http://127.0.0.1:1702'
+session = json.loads(urllib.request.urlopen(f'{base}/api/session/bootstrap').read().decode())['sessionId']
+shells = json.loads(urllib.request.urlopen(f'{base}/api/shells?sessionId={session}').read().decode())
+shell_id = shells['currentShellId']
+
+payload = json.dumps({
+    'sessionId': session,
+    'shellId': shell_id,
+    'command': 'printf BINARY_OK',
+}).encode()
+
+request = urllib.request.Request(
+    f'{base}/api/shells/exec',
+    data=payload,
+    headers={'Content-Type': 'application/json'},
+)
+response = json.loads(urllib.request.urlopen(request, timeout=20).read().decode())
+
+if 'BINARY_OK' not in response.get('output', ''):
+    raise SystemExit(f"unexpected shell output: {response}")
+PY

--- a/tests/ci/start-app.sh
+++ b/tests/ci/start-app.sh
@@ -7,7 +7,7 @@ export BUN_INSTALL=/root/.bun
 export PATH="$BUN_INSTALL/bin:$PATH"
 
 apt-get update >/dev/null
-apt-get install -y --no-install-recommends ca-certificates curl unzip python3 make g++ openssh-client >/dev/null
+apt-get install -y --no-install-recommends ca-certificates curl unzip python3 make g++ openssh-client util-linux >/dev/null
 
 if ! command -v bun >/dev/null 2>&1; then
   curl -fsSL https://bun.sh/install | bash >/dev/null


### PR DESCRIPTION
## Summary
- replace the native `node-pty` dependency with a `script`-backed terminal wrapper so the server can run under Bun and compile into a binary
- add Bun-focused scripts for running the server directly and producing `dist-bin/dynamic-lcars`, plus optional SSH port support for non-default targets
- document the experimental binary workflow and the host requirement for `ssh` plus `script`/`util-linux`

## Testing
- `npm run build`
- `npx tsc --noEmit`
- `npm run build:binary`
- launched the compiled binary locally and verified `GET /api/health`
- launched the Bun server against the local SSH fixture and verified shell exec state persistence across requests
- Vela build `#28` passed for commit `aef2544`

## Notes
- this keeps the existing Docker path intact while proving the server can ship as a Bun-compiled binary
- the compiled binary still expects the built frontend assets in `dist/` next to it